### PR TITLE
Implement frame-synced envelope stop logic for frog physics oscillator

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+     <meta charset="UTF-8">
+     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+     <title>The Semantified Void</title>
+     <style>
+         :root {
+             --surface-warm-800: #8B4513;
+             --surface-warm-900: #5D2906;
+             --surface-warm-1000: #FFA500;
+             --void-bg: #000000;
+         }
+
+         * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+         }
+
+        body {
+            background-color: var(--void-bg);
+            font-family: 'Courier New', monospace;
+            overflow: hidden;
+            height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            position: relative;
+         }
+
+         #grid {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-image:
+                linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+            background-size: 20px 20px;
+            opacity: 0.7;
+         }
+
+         #frog {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--surface-warm-800);
+            border-radius: 50%;
+            cursor: pointer;
+            transition: transform 0.2s ease;
+            z-index: 10;
+            box-shadow: 0 0 10px rgba(139, 69, 19, 0.5);
+         }
+
+         #frog:hover {
+            transform: scale(1.1);
+         }
+
+         #impact-effect {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            background-color: var(--surface-warm-1000);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.1s ease;
+         }
+
+         #idle-hum {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            background-color: var(--void-bg);
+            opacity: 0.1;
+         }
+
+         .frog-trail {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background-color: var(--surface-warm-800);
+            border-radius: 50%;
+            opacity: 0.7;
+         }
+
+         .instructions {
+            position: absolute;
+            bottom: 20px;
+            left: 0;
+            width: 100%;
+            text-align: center;
+            color: rgba(255, 255, 255, 0.7);
+            font-size: 14px;
+            z-index: 20;
+         }
+
+         .status {
+            position: absolute;
+            top: 20px;
+            left: 0;
+            width: 100%;
+            text-align: center;
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 18px;
+            z-index: 20;
+         }
+
+         .tritone {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+         }
+
+     </style>
+</head>
+<body>
+     <div id="grid"></div>
+     <div id="idle-hum"></div>
+     <div id="frog"></div>
+     <div id="impact-effect"></div>
+     <div class="status">Physics Lock: <span id="lock-status">Idle</span></div>
+     <div class="instructions">Hover or click to trigger physics lock</div>
+
+     <script>
+        class PhysicsEngine {
+            constructor() {
+                this.frog = document.getElementById('frog');
+                this.grid = document.getElementById('grid');
+                this.idleHum = document.getElementById('idle-hum');
+                this.impactEffect = document.getElementById('impact-effect');
+                this.lockStatus = document.getElementById('lock-status');
+                this.audioContext = null;
+                this.oscillator = null;
+                this.gainNode = null;
+                this.isLocked = false;
+                this.tritoneTriggered = false;
+
+                 // Physics parameters
+                this.tolerance = 2; // 2px tolerance lock
+                this.initialPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+                this.targetPosition = { x: 0, y: 0 };
+                this.currentPosition = { ...this.initialPosition };
+                this.velocity = { x: 0, y: 0 };
+                this.gravity = 0.2;
+                this.friction = 0.98;
+                this.isAnimating = false;
+
+                // Envelope decay parameters (surface-warm-800 curve)
+                this.envelope = 1.0;
+                this.envelopeDecayRate = 0.96; // per-frame multiplicative decay
+
+                this.init();
+             }
+
+            init() {
+                this.setupAudio();
+                this.setupEventListeners();
+                this.startIdleHum();
+                this.animate();
+             }
+
+            setupAudio() {
+                 // Create audio context if it doesn't exist
+                if (!window.AudioContext) {
+                    console.warn('Web Audio API is not supported in this browser');
+                    return;
+                 }
+
+                this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+             }
+
+            setupEventListeners() {
+                 // Mouse/touch events for physics lock
+                this.frog.addEventListener('mouseenter', () => {
+                    this.lockPhysics();
+                 });
+
+                this.frog.addEventListener('click', () => {
+                    this.lockPhysics();
+                 });
+
+                 // Reset physics when leaving the frog area
+                this.frog.addEventListener('mouseleave', () => {
+                    if (this.isLocked) {
+                        this.resetPhysics();
+                     }
+                 });
+             }
+
+            lockPhysics() {
+                if (this.isLocked) return;
+
+                this.isLocked = true;
+                this.lockStatus.textContent = 'Locked';
+                this.lockStatus.style.color = '#FFA500';
+
+                 // Set random target position (within bounds)
+                this.targetPosition.x = Math.random() * (window.innerWidth - 100) + 50;
+                this.targetPosition.y = Math.random() * (window.innerHeight - 100) + 50;
+
+                 // Calculate initial velocity (overshoot with cubic-bezier curve)
+                const dx = this.targetPosition.x - this.initialPosition.x;
+                const dy = this.targetPosition.y - this.initialPosition.y;
+
+                 // Apply cubic-bezier overshoot calculation
+                this.velocity.x = dx * 1.5;
+                this.velocity.y = dy * 1.5;
+
+                this.isAnimating = true;
+                this.tritoneTriggered = false;
+             }
+
+            resetPhysics() {
+                this.isLocked = false;
+                this.lockStatus.textContent = 'Idle';
+                this.lockStatus.style.color = 'rgba(255, 255, 255, 0.9)';
+                this.isAnimating = false;
+                this.velocity = { x: 0, y: 0 };
+                this.currentPosition = { ...this.initialPosition };
+                this.frog.style.left = this.currentPosition.x + 'px';
+                this.frog.style.top = this.currentPosition.y + 'px';
+
+                // Start envelope decay for frame-synced oscillator stop
+                this.startEnvelopeDecay();
+             }
+
+            startEnvelopeDecay() {
+                // Reset envelope to full, then begin decaying each animation frame
+                if (this.gainNode) {
+                    const now = this.audioContext.currentTime;
+                    this.gainNode.gain.setValueAtTime(this.envelope, now);
+                    // Schedule smooth fade-out via exponential ramp on gain node too
+                    this.gainNode.gain.exponentialRampToValueAtTime(0.001, now + 2.0);
+                }
+             }
+
+            applyEnvelopeDecay() {
+                 // Frame-synced envelope stop: decay multiplicative curve each frame
+                this.envelope *= this.envelopeDecayRate;
+
+                 // Apply current envelope value to gain node (silent if oscillator stopped)
+                if (this.gainNode && this.oscillator) {
+                    const now = this.audioContext.currentTime;
+                    this.gainNode.gain.setTargetAtTime(this.envelope, now, 0.01);
+                 }
+             }
+
+            hardStopOscillator() {
+                 // Frame-synced envelope threshold check hit: <= 0.001 → hard-stop oscillator and release buffer
+                if (this.oscillator) {
+                    try {
+                        this.oscillator.stop();
+                     } catch (_) {}
+                    this.oscillator.disconnect();
+                    this.oscillator = null;
+                 }
+
+                 // Release gain node buffer
+                if (this.gainNode) {
+                    this.gainNode.disconnect();
+                    this.gainNode = null;
+                 }
+
+                 // Reset envelope state for next trigger
+                this.envelope = 1.0;
+             }
+
+            startIdleHum() {
+                 // Create a 50Hz sine wave for idle hum
+                if (this.audioContext) {
+                    this.oscillator = this.audioContext.createOscillator();
+                    this.gainNode = this.audioContext.createGain();
+
+                    this.oscillator.type = 'sine';
+                    this.oscillator.frequency.value = 50;
+                    this.gainNode.gain.value = this.envelope; // start at full envelope
+
+                    this.oscillator.connect(this.gainNode);
+                    this.gainNode.connect(this.audioContext.destination);
+
+                    this.oscillator.start();
+                 }
+             }
+
+            playTritone() {
+                if (this.audioContext && !this.tritoneTriggered) {
+                    this.tritoneTriggered = true;
+
+                     // Stop the idle hum via frame-synced envelope decay path
+                     // First, apply envelope decay from current state instead of abrupt stop
+                    if (this.gainNode) {
+                        const now = this.audioContext.currentTime;
+                        this.gainNode.gain.cancelScheduledValues(now);
+                        this.gainNode.gain.setValueAtTime(this.envelope, now);
+                        this.gainNode.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+                     }
+
+                    // Wait a brief moment for envelope to reach threshold, then hard-stop
+                    const t = setTimeout(() => {
+                        if (this.oscillator) {
+                            try { this.oscillator.stop(); } catch (_) {}
+                            this.oscillator.disconnect();
+                            this.oscillator = null;
+                         }
+                        if (this.gainNode) {
+                            this.gainNode.disconnect();
+                            this.gainNode = null;
+                         }
+                        this.envelope = 1.0;
+
+                         // Create tritone (A-flat) — approximately 466.16 Hz
+                        const tritoneFreq = 466.16;
+                        const oscillator = this.audioContext.createOscillator();
+                        const gainNode = this.audioContext.createGain();
+
+                        oscillator.type = 'sawtooth';
+                        oscillator.frequency.value = tritoneFreq;
+                        gainNode.gain.value = 0.5;
+
+                        oscillator.connect(gainNode);
+                        gainNode.connect(this.audioContext.destination);
+
+                        oscillator.start();
+                        oscillator.stop(this.audioContext.currentTime + 0.2); // 200ms duration
+
+                         // Trigger visual impact effect
+                        this.impactEffect.style.opacity = '0.8';
+                        setTimeout(() => {
+                            this.impactEffect.style.opacity = '0';
+                         }, 100);
+
+                         // Reset after a short delay
+                        setTimeout(() => {
+                            this.resetPhysics();
+                         }, 500);
+                     }, 200);
+
+                    this._tritoneTimer = t;
+                 }
+             }
+
+            animate() {
+                if (!this.isAnimating) {
+                    requestAnimationFrame(() => this.animate());
+                    return;
+                 }
+
+                 // Apply physics
+                this.velocity.y += this.gravity;
+                this.currentPosition.x += this.velocity.x;
+                this.currentPosition.y += this.velocity.y;
+
+                 // Apply friction
+                this.velocity.x *= this.friction;
+                this.velocity.y *= this.friction;
+
+                 // Update frog position
+                this.frog.style.left = this.currentPosition.x + 'px';
+                this.frog.style.top = this.currentPosition.y + 'px';
+
+                 // Frame-synced envelope decay check (independent of physics state)
+                if (this.envelope >= 0.001) {
+                     // Envelope above threshold: continue oscillator with decaying gain
+                    this.applyEnvelopeDecay();
+                 } else {
+                     // Envelope at or below threshold: hard-stop oscillator and release buffer
+                    this.hardStopOscillator();
+                 }
+
+                 // Check for impact with target (2px tolerance)
+                const dx = this.currentPosition.x - this.targetPosition.x;
+                const dy = this.currentPosition.y - this.targetPosition.y;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+
+                 // Trigger tritone when within 2px tolerance
+                if (distance <= this.tolerance && !this.tritoneTriggered) {
+                    this.playTritone();
+                 }
+
+                 // Check if frog has passed the target (overshoot)
+                if (distance > 0 && this.isLocked) {
+                     // Add visual trail effect
+                    const trail = document.createElement('div');
+                    trail.className = 'frog-trail';
+                    trail.style.left = this.currentPosition.x + 'px';
+                    trail.style.top = this.currentPosition.y + 'px';
+                    document.body.appendChild(trail);
+
+                     // Remove trail after a short time
+                    setTimeout(() => {
+                        trail.remove();
+                     }, 500);
+                 }
+
+                 // Continue animation loop
+                requestAnimationFrame(() => this.animate());
+             }
+         }
+
+         // Initialize the physics engine when the page loads
+        window.addEventListener('load', () => {
+            const physicsEngine = new PhysicsEngine();
+         });
+
+         // Handle window resize
+        window.addEventListener('resize', () => {
+             // Update grid background size on resize
+            const grid = document.getElementById('grid');
+            grid.style.backgroundSize = '20px 20px';
+         });
+
+     </script>
+</body>
+</html>


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics oscillator

Modify the frog physics simulation to ensure the sine wave oscillator stops exactly when the envelope reaches zero, eliminating audible clicks at frame transitions. Use the existing '--surface-warm-800' decay curve without modification. Implement a frame-synced check where if envelope >= 0.001, continue; if envelope <= 0.001, hard-stop the oscillator and release the buffer. Verify the math locally before pushing to the shared repo.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.