### PR TITLE
Implement frame-synced envelope stop logic for frog physics audio

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -293,6 +293,16 @@
                 this.lockStatus.textContent = 'Released';
                 this.lockStatus.style.color = '#8B4513';
                 this.envValue.textContent = '0.0000';
+                 // Freeze frog sprite simultaneously with audio cut-off
+                 // Zero velocity to halt all motion; clamp position to last valid frame
+                this.velocity.x = 0;
+                this.velocity.y = 0;
+                const W = window.innerWidth;
+                const H = window.innerHeight;
+                this.currentPosition.x = Math.max(0, Math.min(this.currentPosition.x, W - 60));
+                this.currentPosition.y = Math.max(0, Math.min(this.currentPosition.y, H - 60));
+                this.frog.style.left = this.currentPosition.x + 'px';
+                this.frog.style.top = this.currentPosition.y + 'px';
              }
 
             playTritone() {


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics audio

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check that stops the sine oscillator exactly when the envelope reaches zero (using the '--surface-warm-800' decay curve), ensuring no audible clicks or pops at frame transitions. The frog sprite must also stop moving simultaneously with the audio cut-off.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.