### PR TITLE
Implement frame-synced envelope stop condition for frog physics oscillator

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -233,12 +233,6 @@
                     this.peakAmplitude,
                     this.audioContext.currentTime + 0.01
                 );
-                 // Continuous exponential decay toward silence (τ ≈ 5.6s)
-                this.gainNode.gain.setTargetAtTime(
-                     0,
-                    this.audioContext.currentTime + 0.01,
-                     5.6
-                  );
 
                 this.oscillator.connect(this.gainNode);
                 this.gainNode.connect(this.audioContext.destination);
@@ -267,6 +261,10 @@
                  // stop early on the exact 0.001 boundary frame)
                 if (envelope > 0.001) {
                      // Continue: frog still bounces, sound plays
+                       // Apply per-frame envelope gain for mathematical continuity.
+                   this.gainNode.gain.setValueAtTime(
+                        envelope * this.peakAmplitude, this.audioContext.currentTime
+                       );
                     return;
                  }
                  // envelope <= 0.001 -- the envelope has decayed to near-zero.


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop condition for frog physics oscillator

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. The oscillator must stop exactly when the envelope reaches zero (<= 0.001), using the existing '--surface-warm-800' decay curve. Implement a frame-synced check that halts the oscillator and releases the buffer when the envelope value drops below the threshold, eliminating audible clicks at frame transitions.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.