### PR TITLE
Implement frame-synced envelope stop condition for frog physics oscillator

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -262,9 +262,10 @@
                 if (envelope > 0.001) {
                      // Continue: frog still bounces, sound plays
                        // Apply per-frame envelope gain for mathematical continuity.
-                   this.gainNode.gain.setValueAtTime(
-                        envelope * this.peakAmplitude, this.audioContext.currentTime
-                       );
+                this.gainNode.gain.exponentialRampToValueAtTime(
+                    Math.max(envelope * this.peakAmplitude, 1e-7),
+                    this.audioContext.currentTime + (1 / 60)
+                );
                     return;
                  }
                  // envelope <= 0.001 -- the envelope has decayed to near-zero.
@@ -290,7 +291,7 @@
                   // This guarantees smooth mathematical continuity across the
                   // frame boundary where envelope <= 0.001, eliminating any click.
                 try {
-                     // Cancel pending per-frame setValueAtTime calls so the ramp
+                     // Cancel all pending per-frame gain schedules so the ramp
                      // starts from the true current gain — prevents step discontinuity.
                      this.gainNode.gain.cancelScheduledValues(now);
                      this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now);


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop condition for frog physics oscillator

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check where the oscillator continues if envelope >= 0.001, and stops exactly when envelope <= 0.001. Verify the '--surface-warm-800' decay curve is applied without modification. Ensure no audible clicks or pops at frame transitions.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.