### PR TITLE
Implement frame-synced envelope stop logic for frog physics oscillator

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -272,8 +272,6 @@
                    // Hard clamp: envelope never interpolates past the zero threshold.
                    // When below cutoff, stop scheduling new gain values — no ramping through.
                 if (envelope <= 0.001) {
-                    this.frameCount += 2;
-                    this.stopFrame++;
                     this.hardStopOscillator();
                     return;
                   }
@@ -295,8 +293,6 @@
                */
             hardStopOscillator() {
                 if (!this.oscillator) return;
-
-                if (this.stopFrame > 0) return;
 
                 const now = this.audioContext.currentTime;
 
@@ -333,6 +329,7 @@
                 this.currentPosition.y = Math.max(0, Math.min(this.currentPosition.y, H - 60));
                 this.velocity.x = 0;
                 this.velocity.y = 0;
+                this.isAnimating = false;
                 this.frog.style.left = this.currentPosition.x + 'px';
                 this.frog.style.top = this.currentPosition.y + 'px';
              }


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics oscillator

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check that stops the sine oscillator exactly when the envelope value reaches zero (<= 0.001), ensuring no audible clicks at frame transitions. Use the existing '--surface-warm-800' decay curve without modification. The oscillator must halt immediately at frame N where envelope hits zero, and the frog sprite must stop moving simultaneously with the audio cut-off.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.