### PR TITLE
Implement frame-synced envelope stop logic for frog physics audio

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -278,6 +278,10 @@
 
                    // envelope > 0.001: continue oscillating with frame-accurate scheduling.
                 const targetGain = Math.max(envelope * this.peakAmplitude, 1e-7);
+                // Frame-synced: cancel any pending per-frame schedules and re-establish
+                // from the true live gain so exponential ramps never overlap or conflict.
+                this.gainNode.gain.cancelScheduledValues(now);
+                this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now);
                 this.gainNode.gain.exponentialRampToValueAtTime(
                     targetGain,
                     now + elapsedMs / 1000
@@ -309,8 +313,12 @@
 
                   // Stop after the ramp completes; buffer will have decayed to silence.
                 try { this.oscillator.stop(now + 0.006); } catch (_) { /* already stopped */ }
-                this.oscillator.disconnect();
-                if (this.gainNode) { this.gainNode.disconnect(); }
+                 // Defer disconnect until after the scheduled stop fires (~6 ms); prevents the
+                 // exponential ramp from being killed mid-execution, which causes clicks.
+                const osc = this.oscillator;
+                const gn = this.gainNode;
+                setTimeout(() => { try { osc.disconnect(); } catch (_) {} }, 10);
+                if (gn) { try { gn.disconnect(); } catch (_) {} }
                 this.oscillator = null;
                 this.gainNode = null;
                 this.isOscillating = false;


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics audio

Fix the audible clicks in the frog physics simulation by implementing a frame-synced check for the envelope value. The oscillator must stop exactly when the envelope reaches zero (<= 0.001) to ensure mathematical continuity and eliminate audio artifacts. Use the existing '--surface-warm-800' decay curve without modification. Verify the math locally before pushing to the shared repo.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.