### PR TITLE
Implement frame-synced envelope stop logic for frog physics simulation

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -254,7 +254,8 @@
                 if (!this.isOscillating || !this.oscillator) return;
 
                     // time-continuous decay from surface-warm-800 curve.
-                const halfLifeMs = -Math.log(2) / Math.log(this.decayRate);
+                // Frame duration for frame-synced envelope: decayRate applies once per frame
+				const halfLifeMs = 1000 / 60; // ~16.67ms per frame at 60fps target
                     // Clamp elapsedS to zero minimum: prevents audio clock drift from
                     // producing negative elapsed time that would cause the exponential
                     // to grow instead of decay (audible clicks/pops).


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics simulation

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check that stops the sine oscillator exactly when the envelope reaches zero (using the '--surface-warm-800' decay curve), ensuring no audible clicks or pops at frame transitions. The frog sprite must also stop moving simultaneously with the audio cut-off.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.