### PR TITLE
Implement frame-synced envelope stop logic for frog physics simulation

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -268,23 +268,15 @@
                     return;
                    }
 
-                    // envelope > 0.001: continue oscillating with frame-accurate scheduling.
-                    // Schedule a continuous exponential decay curve that covers at least
-                    // one full rAF cycle (≥50 ms) so that even if the next frame is
-                    // dropped by system load or tab throttling, there is no gap in the
-                    // gain timeline — Web Audio uses the last scheduled value until
-                    // the new exponential curve takes over, maintaining continuity.
-                const targetGain = Math.max(envelope * this.peakAmplitude, 1e-7);
-                 // Frame-synced: cancel any pending per-frame schedules and re-establish
-                 // from the true live gain so exponential ramps never overlap or conflict.
+                  // envelope > 0.001: continue oscillating with exact
+                  // sample-accurate gain scheduling — no overlapping ramps.
+                  // Each rAF sets the precise gain from decayRate^frameCount
+                  // at that audio-time point, ensuring mathematical continuity.
                 const now = this.audioContext.currentTime;
+                const targetGain = Math.max(envelope * this.peakAmplitude, 1e-7);
 
                 this.gainNode.gain.cancelScheduledValues(now);
-                this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now);
-                this.gainNode.gain.exponentialRampToValueAtTime(
-                    targetGain,
-                    now + 0.05         // look-ahead: ≥1 rAF frame to absorb skips
-                   );
+                this.gainNode.gain.setValueAtTime(targetGain, now);
                 return;
               }
                /**


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics simulation

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check that stops the sine oscillator exactly when the envelope reaches zero (<= 0.001), using the '--surface-warm-800' decay curve without modification. Ensure no audible clicks or pops at frame transitions and that the frog sprite stops moving simultaneously with the audio cut-off.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.