### PR TITLE
Implement frame-synced envelope stop logic for frog physics audio

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -5,14 +5,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Frog Physics Oscillator</title>
 	<style>
-	    :root {
-	        --surface-warm-800: #8B4513;
-	        --surface-warm-900: #5D2906;
-	        --surface-warm-1000: #FFA500;
-	        --void-bg: #000000;
-	    }
+	     :root {
+	         --surface-warm-800: #8B4513;
+	         --surface-warm-900: #5D2906;
+	         --surface-warm-1000: #FFA500;
+	         --void-bg: #000000;
+	     }
 
-	    * { margin: 0; padding: 0; box-sizing: border-box; }
+	     * { margin: 0; padding: 0; box-sizing: border-box; }
 
 	 body {
 	     background-color: var(--void-bg);
@@ -23,9 +23,9 @@
 	     justify-content: center;
 	     align-items: center;
 	     position: relative;
-	    }
+	 }
 
-	    #grid {
+	     #grid {
 	     position: absolute;
 	     top: 0; left: 0; width: 100%; height: 100%;
 	     background-image:
@@ -33,9 +33,9 @@
 	         linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
 	     background-size: 20px 20px;
 	     opacity: 0.7;
-	    }
+	 }
 
-	    #frog {
+	     #frog {
 	     position: absolute;
 	     width: 60px; height: 60px;
 	     background-color: var(--surface-warm-800);
@@ -43,40 +43,40 @@
 	     cursor: pointer;
 	     z-index: 10;
 	     box-shadow: 0 0 10px rgba(139, 69, 19, 0.5);
-	    }
+	 }
 
-	    #frog:hover { transform: scale(1.1); }
+	     #frog:hover { transform: scale(1.1); }
 
-	    #impact-effect {
+	     #impact-effect {
 	     position: absolute; width: 100%; height: 100%;
 	     background-color: var(--surface-warm-1000);
 	     opacity: 0; pointer-events: none; transition: opacity 0.1s ease;
-	    }
+	 }
 
-	    .frog-trail {
+	     .frog-trail {
 	     position: absolute;
 	     width: 20px; height: 20px;
 	     background-color: var(--surface-warm-800);
 	     border-radius: 50%; opacity: 0.7;
-	    }
+	 }
 
-	    .status {
+	     .status {
 	     position: absolute; top: 20px; left: 0; width: 100%;
 	     text-align: center; color: rgba(255, 255, 255, 0.9);
 	     font-size: 18px; z-index: 20;
-	    }
+	 }
 
-	    .envelope-display {
+	     .envelope-display {
 	     position: absolute; bottom: 60px; left: 0; width: 100%;
 	     text-align: center; color: rgba(139, 69, 19, 0.9);
 	     font-size: 14px; z-index: 20;
-	    }
+	 }
 
-	    .instructions {
+	     .instructions {
 	     position: absolute; bottom: 20px; left: 0; width: 100%;
 	     text-align: center; color: rgba(255, 255, 255, 0.7);
 	     font-size: 14px; z-index: 20;
-	    }
+	 }
 	</style>
 </head>
 <body>
@@ -89,20 +89,20 @@
 	<div class="instructions">Click the frog to trigger physics + oscillator</div>
 
 	<script>
-	   /**
-	    * Frog Physics Oscillator with frame-synced envelope stop.
-	    *
-	    * Decay curve: "surface-warm-800" derived from color #8B4513
-	    *      - Red channel (R=139) -> decay rate = R/255 ~ 0.545
-	    *      - Green channel (G=69)    -> peak envelope = G/255 ~ 0.271
-	    *      - Blue channel (B=19)     -> shadow intensity
-	    *
-	    * Frame-synced logic (runs at ~60 fps):
-	    *   envelope = decayRate ^ frameCount        [corrected: per-frame, not /60]
-	    *   gainNode.gain.value = envelope * peakAmplitude
-	    *   if envelope >= 0.001: continue oscillating
-	    *   if envelope < 0.001: hard-stop oscillator & release buffer
-	    */
+	    /**
+	     * Frog Physics Oscillator with frame-synced envelope stop.
+	     *
+	     * Decay curve: "surface-warm-800" derived from color #8B4513
+	     *       - Red channel (R=139) -> decay rate = R/255 ~ 0.545
+	     *       - Green channel (G=69)     -> peak envelope = G/255 ~ 0.271
+	     *       - Blue channel (B=19)      -> shadow intensity
+	     *
+	     * Frame-synced logic (runs at ~60 fps):
+	     *   envelope = decayRate ^ frameCount
+	     *   gainNode.gain.value = envelope * peakAmplitude
+	     *   if envelope >= 0.001: continue oscillating with continuous envelope ramp
+	     *   if envelope < 0.001: hard-stop oscillator & release buffers
+	     */
 
 	   class FrogPhysicsOscillator {
 	       constructor() {
@@ -112,20 +112,20 @@
 	           this.lockStatus = document.getElementById('lock-status');
 	           this.envValue = document.getElementById('env-value');
 
-	              // AudioContext (initialized on first interaction)
+	               // AudioContext (initialized on first interaction)
 	           this.audioContext = null;
 	           this.oscillator = null;
 	           this.gainNode = null;
 	           this.buffersCleared = false;
 
-	              // --- surface-warm-800 decay curve parameters ---
-	              // #8B4513 -> R=139, G=69, B=19
+	               // --- surface-warm-800 decay curve parameters ---
+	               // #8B4513 -> R=139, G=69, B=19
 	           const R = 0x8B; // 139
 	           const G = 0x45; // 69
-	           this.decayRate = R / 255;       // ~ 0.545 -- per-frame decay factor
+	           this.decayRate = R / 255;        // ~ 0.545 -- per-frame decay factor
 	           this.peakAmplitude = G / 255; // ~ 0.271 -- initial envelope peak
 
-	              // Physics parameters
+	               // Physics parameters
 	           this.tolerance = 2; // 2px tolerance for lock
 	           this.initialPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
 	           this.targetPosition = { x: 0, y: 0 };
@@ -134,43 +134,43 @@
 	           this.gravity = 0.2;
 	           this.friction = 0.98;
 
-	              // Animation state
+	               // Animation state
 	           this.isLocked = false;
 	           this.isAnimating = false;
 	           this.tritoneTriggered = false;
 
-	              // Oscillator state
+	               // Oscillator state
 	           this.oscillatorStartTime = 0;
 	           this.isOscillating = false;
-	               // Frame-sync tracking for accurate audio scheduling
+	                // Frame-sync tracking for accurate audio scheduling
 	           this.lastAudioTime = 0;
 	           this.stopFrame = 0;
 
 	           this.init();
-	          }
+	           }
 
 	       init() {
 	           this.setupAudio();
 	           this.setupEventListeners();
 	           this.animate();
-	          }
+	           }
 
 	       setupAudio() {
 	           if (!window.AudioContext) {
 	               console.warn('Web Audio API is not supported in this browser');
 	               return;
-	             }
+	              }
 	           this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
-	          }
+	           }
 
 	       setupEventListeners() {
 	           this.frog.addEventListener('click', () => this.lockPhysics());
-	              // Also respond to mouseenter for interactive feel
+	               // Also respond to mouseenter for interactive feel
 	           this.frog.addEventListener('mouseenter', () => this.lockPhysics());
 	           this.frog.addEventListener('mouseleave', () => {
 	               if (this.isLocked) this.resetPhysics();
-	             });
-	          }
+	              });
+	           }
 
 	       lockPhysics() {
 	           if (this.isLocked) return;
@@ -182,11 +182,11 @@
 	           this.lockStatus.textContent = 'Locked';
 	           this.lockStatus.style.color = '#FFA500';
 
-	              // Random target position within bounds
+	               // Random target position within bounds
 	           this.targetPosition.x = Math.random() * (window.innerWidth - 100) + 50;
 	           this.targetPosition.y = Math.random() * (window.innerHeight - 100) + 50;
 
-	              // Calculate initial velocity with overshoot
+	               // Calculate initial velocity with overshoot
 	           const dx = this.targetPosition.x - this.initialPosition.x;
 	           const dy = this.targetPosition.y - this.initialPosition.y;
 	           this.velocity.x = dx * 1.5;
@@ -194,12 +194,12 @@
 
 	           this.isAnimating = true;
 
-	              // Start oscillator only when AudioContext is active (resumes if suspended)
+	               // Start oscillator only when AudioContext is active (resumes if suspended)
 	           if (this.audioContext && this.audioContext.state === 'suspended') {
 	               this.audioContext.resume();
-	             }
+	              }
 	           this.startOscillator();
-	          }
+	           }
 
 	       resetPhysics() {
 	           this.isLocked = false;
@@ -211,16 +211,16 @@
 	           this.lockStatus.textContent = 'Idle';
 	           this.lockStatus.style.color = 'rgba(255, 255, 255, 0.9)';
 
-	              // Stop oscillator via frame-synced envelope (soft stop, no click)
+	               // Stop oscillator via frame-synced envelope (soft stop, no click)
 	           if (this.isOscillating) {
 	               this.hardStopOscillator();
-	             }
-	          }
+	              }
+	           }
 
-	          /**
-	           * Start the sine wave oscillator with smooth gain ramp-up.
-	           * Envelope begins at peakAmplitude and decays per surface-warm-800 curve.
-	           */
+	           /**
+	            * Start the sine wave oscillator with smooth gain ramp-up.
+	            * Envelope begins at peakAmplitude and decays per surface-warm-800 curve.
+	            */
 	       startOscillator() {
 	           if (!this.audioContext) return;
 
@@ -231,85 +231,98 @@
 	           this.oscillator.frequency.value = 440; // A4 tone
 	           this.stopFrame = 0;
 	           this.gainNode.gain.setValueAtTime(0, this.audioContext.currentTime);
-	              // Smooth ramp from 0 to peak to avoid initial click
+	               // Smooth ramp from 0 to peak to avoid initial click
 	           this.gainNode.gain.exponentialRampToValueAtTime(
 	               this.peakAmplitude,
 	               this.audioContext.currentTime + 0.01
-	             );
+	              );
 
 	           this.oscillator.connect(this.gainNode);
 	           this.gainNode.connect(this.audioContext.destination);
 	           this.oscillator.start();
-	              // Record audio context time when oscillator begins; used for frame-synced envelope stop.
+	               // Record audio context time when oscillator begins; used for frame-synced envelope stop.
 	           this.oscillatorStartTime = this.audioContext.currentTime;
-	          }
+	           }
 
-	          /**
-	           * Frame-synced envelope update + stop check.
-	           * Called every animation frame (rAF ~ 60 fps).
-	           *
-	           * If envelope >= 0.001: continue oscillating with updated gain.
-	           * If envelope < 0.001: hard-stop oscillator and release buffers.
-	           */
+	           /**
+	            * Frame-synced envelope update + stop check.
+	            * Called every animation frame (rAF ~60 fps).
+	            *
+	            * Envelope decay: envelope = decayRate ^ stopFrame  [discrete, per-frame]
+	            * Gain scheduling: uses exponentialRampToValueAtTime from the audio thread's
+	            *   actual running value toward targetGain over ~16ms, maintaining mathematical
+	            *   continuity of the gain curve across frame transitions — no piecewise steps,
+	            *   no clicks or pops at rAF boundaries.
+	            *
+	            * If envelope >= 0.001: continue oscillating with continuous exponential envelope.
+	            * If envelope < 0.001: hard-stop oscillator and release buffers.
+	            */
 	       updateEnvelope() {
 	           if (!this.isOscillating || !this.oscillator) return;
 
-	            // Discrete per-frame decay: decayRate^frameCount — mathematically exact stop.
+	             // Discrete per-frame decay: decayRate^frameCount — mathematically exact stop.
 	           this.stopFrame += 1;
 	           const envelope = Math.pow(this.decayRate, this.stopFrame);
 
-	            // Display current envelope value for debugging
+	             // Display current envelope value for debugging
 	           this.envValue.textContent = envelope.toFixed(6);
-	                // --- Frame-synced envelope stop logic ---
-	                // Hard clamp: envelope never interpolates past the zero threshold.
-	                // When below cutoff, hard-stop with a clean exponential fade to silence.
+	                 // --- Frame-synced envelope stop logic ---
+	                 // Hard clamp: envelope never interpolates past the zero threshold.
+	                 // When below cutoff, hard-stop with a clean exponential fade to silence.
 	           if (envelope < 0.001) {
 	               this.hardStopOscillator();
 	               return;
-	               }
+	                }
 
-	               // envelope >= 0.001: frame-synced gain update with continuous
-	               // anti-click pre-anchoring.  cancelScheduledValues(now) ensures no
-	               // stale schedules linger at this rAF boundary; the subsequent
-	               // setValueAtTime re-anchors the curve to our decayRate^stopFrame
-	               // value, maintaining exact mathematical continuity across frames.
+	                // envelope >= 0.001: continuous exponential envelope update.
+	                // Read the audio thread's actual running gain value and ramp toward
+	                // targetGain over one frame interval (~16ms).  This preserves exact
+	                // mathematical continuity at every rAF boundary — no piecewise
+	                // constant steps, no discontinuities between consecutive frames.
 	           const now = this.audioContext.currentTime;
 	           const targetGain = Math.max(envelope * this.peakAmplitude, 1e-7);
 	           try {
 	               this.gainNode.gain.cancelScheduledValues(now);
-	               this.gainNode.gain.setValueAtTime(targetGain, now);
-	            } catch (_) {}
+	               // Re-anchor from audio-thread's exact current gain (mathematical continuity)
+	               this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now);
+	               // Continuous exponential ramp toward target — no step discontinuity.
+	               this.gainNode.gain.exponentialRampToValueAtTime(
+	                   targetGain,
+	                   now + 0.016
+	                  );
+	             } catch (_) {}
 	           return;
-	          }
-	          /**
-	           * Hard-stop the oscillator: ramp gain to zero then stop & disconnect.
-	           * Called only when envelope is already below the threshold — uses an
-	           * exponential fade-out for smooth decay-to-silence, followed by a firm
-	           * oscillator cut-off so both audio and visual stop on the same frame.
-	           */
+	           }
+
+	           /**
+	            * Hard-stop the oscillator: ramp gain to zero then stop & disconnect.
+	            * Called only when envelope is already below the threshold — uses an
+	            * exponential fade-out for smooth decay-to-silence, followed by a firm
+	            * oscillator cut-off so both audio and visual stop on the same frame.
+	            */
 	       hardStopOscillator() {
 	           if (!this.oscillator) return;
 
 	           const now = this.audioContext.currentTime;
 
-	               // Cancel all per-frame gain schedules and linear-ramp gain from
-	                // its current running value to near-zero over 1 ms — the shortest
-	                // practical interval that yields mathematically continuous decay with no
+	                // Cancel all per-frame gain schedules and ramp from its current
+	                // running value to near-zero over 3 ms — the shortest practical
+	                // interval that yields mathematically continuous decay with no
 	                // clicks or pops.
 	           try {
 	               this.gainNode.gain.cancelScheduledValues(now);
-	               // Re-anchor: guarantees the ramp starts from the audio thread's exact
-	               // current gain (mathematical continuity at frame boundary).
+	                // Re-anchor: guarantees the ramp starts from the audio thread's exact
+	                // current gain (mathematical continuity at frame boundary).
 	               this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, now);
-	               // Smooth exponential fade to near-silence over 3 ms — better matches
-	               // the natural decay curve of the surface-warm-800 envelope and avoids
-	               // the sharp corner a linear ramp introduces at the stop transition.
+	                // Smooth exponential fade to near-silence over 3 ms — better matches
+	                // the natural decay curve of the surface-warm-800 envelope and avoids
+	                // the sharp corner a linear ramp introduces at the stop transition.
 	               this.gainNode.gain.exponentialRampToValueAtTime(1e-7, now + 0.003);
-	              } catch (_) { /* gainNode may be undefined */ }
+	               } catch (_) { /* gainNode may be undefined */ }
 
-	               // Stop oscillator 4 ms after ramp — both audio and visuals freeze
-	               // in the same rAF callback so sprite motion halts simultaneously
-	               // with the exponential envelope reaching its final silence floor.
+	                // Stop oscillator 4 ms after ramp — both audio and visuals freeze
+	                // in the same rAF callback so sprite motion halts simultaneously
+	                // with the exponential envelope reaching its final silence floor.
 	           try { this.oscillator.stop(now + 0.004); } catch (_) { /* already stopped */ }
 	               // Disconnect oscillator and gain node at audio-context-accurate times:
 	               // stop at now+4ms; disconnect immediately after — no setTimeout that
@@ -323,14 +336,14 @@
 	           this.isOscillating = false;
 	           this.buffersCleared = true;
 
-	               // Visual feedback: release lock status
+	                // Visual feedback: release lock status
 	           this.lockStatus.textContent = 'Released';
 	           this.lockStatus.style.color = '#8B4513';
 	           this.envValue.textContent = '0.0000';
 	           this.stopFrame = 0;
-		            // Freeze frog sprite simultaneously with audio cut-off:
-		            // clamp to final position, then zero velocity so no
-		            // further motion can accumulate after the envelope has reached 0.
+		             // Freeze frog sprite simultaneously with audio cut-off:
+		             // clamp to final position, then zero velocity so no
+		             // further motion can accumulate after the envelope has reached 0.
 		          const W = window.innerWidth;
 	           const H = window.innerHeight;
 	           this.currentPosition.x = Math.max(0, Math.min(this.currentPosition.x, W - 60));
@@ -340,18 +353,18 @@
 	           this.isAnimating = false;
 	           this.frog.style.left = this.currentPosition.x + 'px';
 	           this.frog.style.top = this.currentPosition.y + 'px';
-	          }
+	           }
 
 	       playTritone() {
 	           if (!this.audioContext || this.tritoneTriggered) return;
 	           this.tritoneTriggered = true;
 
-	              // Stop oscillator via frame-synced envelope (clean stop)
+	               // Stop oscillator via frame-synced envelope (clean stop)
 	           if (this.isOscillating) {
 	               this.hardStopOscillator();
-	             }
+	              }
 
-	              // Create tritone (A~flat ~ 466.16 Hz) -- sawtooth wave, short burst
+	               // Create tritone (A~flat ~ 466.16 Hz) -- sawtooth wave, short burst
 	           const osc = this.audioContext.createOscillator();
 	           const gn = this.audioContext.createGain();
 	           osc.type = 'sawtooth';
@@ -364,20 +377,20 @@
 	           osc.start();
 	           osc.stop(this.audioContext.currentTime + 0.2);
 
-	              // Visual impact effect
+	               // Visual impact effect
 	           this.impactEffect.style.opacity = '0.8';
 	           setTimeout(() => { this.impactEffect.style.opacity = '0'; }, 100);
 
 	           setTimeout(() => { this.resetPhysics(); }, 500);
-	          }
+	           }
 
 	       animate() {
 	           if (!this.isAnimating) {
 	               requestAnimationFrame(() => this.animate());
 	               return;
-	             }
+	              }
 
-	              // --- Physics update ---
+	               // --- Physics update ---
 	           this.velocity.y += this.gravity;
 	           this.currentPosition.x += this.velocity.x;
 	           this.currentPosition.y += this.velocity.y;
@@ -387,31 +400,31 @@
 	           this.frog.style.left = this.currentPosition.x + 'px';
 	           this.frog.style.top = this.currentPosition.y + 'px';
 
-	              // --- Bounce physics: clamp to viewport and reverse velocity ---
+	               // --- Bounce physics: clamp to viewport and reverse velocity ---
 	           const W = window.innerWidth;
 	           const H = window.innerHeight;
 	           if (this.currentPosition.x < 0 || this.currentPosition.x > W - 60) {
 	               this.velocity.x *= -1;
 	               this.currentPosition.x = Math.max(0, Math.min(this.currentPosition.x, W - 60));
-	             }
+	              }
 	           if (this.currentPosition.y < 0 || this.currentPosition.y > H - 60) {
 	               this.velocity.y *= -1;
 	               this.currentPosition.y = Math.max(0, Math.min(this.currentPosition.y, H - 60));
-	             }
+	              }
 
-	              // --- Oscillator envelope update (frame-synced) ---
+	               // --- Oscillator envelope update (frame-synced) ---
 	           this.updateEnvelope();
 
-	              // --- Impact detection (2px tolerance) ---
+	               // --- Impact detection (2px tolerance) ---
 	           const dx = this.currentPosition.x - this.targetPosition.x;
 	           const dy = this.currentPosition.y - this.targetPosition.y;
 	           const distance = Math.sqrt(dx * dx + dy * dy);
 
 	           if (distance <= this.tolerance && !this.tritoneTriggered) {
 	               this.playTritone();
-	             }
+	              }
 
-	              // --- Visual trail effect on overshoot ---
+	               // --- Visual trail effect on overshoot ---
 	           if (distance > 0 && this.isLocked) {
 	               const trail = document.createElement('div');
 	               trail.className = 'frog-trail';
@@ -419,19 +432,19 @@
 	               trail.style.top = this.currentPosition.y + 'px';
 	               document.body.appendChild(trail);
 	               setTimeout(() => { trail.remove(); }, 500);
-	             }
+	              }
 
 	           requestAnimationFrame(() => this.animate());
-	          }
-	       }
+	           }
+	        }
 
 	   window.addEventListener('load', () => {
 	       new FrogPhysicsOscillator();
-	      });
+	       });
 
 	   window.addEventListener('resize', () => {
 	       document.getElementById('grid').style.backgroundSize = '20px 20px';
-	      });
+	       });
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Automated change by director-scheduler

Implement frame-synced envelope stop logic for frog physics audio

Modify the frog physics simulation to enforce mathematical continuity in the audio envelope decay. Implement a frame-synced check that stops the sine oscillator exactly when the envelope value drops to or below 0.001, using the existing '--surface-warm-800' decay curve. Ensure no audible clicks or pops occur at frame transitions and that the frog sprite stops moving simultaneously with the audio cut-off.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.