### PR TITLE
Assigned task title: Implement Frame-Synced Envelope Termination for Frog Physics Audio

### DIFF
--- a/drops/1776531645396450811/index.html
+++ b/drops/1776531645396450811/index.html
@@ -113,7 +113,7 @@
 	   *   Stop condition (frame-synced):
 	   *     ENVELOPE_THRESHOLD = 0.001
 	   *     stopFrames = ceil(log(0.001) / log(decayRate)) = 12 frames at 60 fps
-	   *     At frame 12: envelope = 0.000688 ~ -74.6 dB (inaudible)
+	   *     At frame 12: envelope = 0.000688 ~ -63.2 dB (inaudible)
 	   *      -> hard-stop oscillator immediately, release buffer, no residual audio
 	   *      -> no cancelScheduledValues needed (nothing was pre-scheduled past this frame)
 	   *
@@ -286,31 +286,32 @@
 					//   envelope(n) = decayRate^n = (R/255)^n
 				var currentEnvelope             = Math.pow(decayRate, animFrameCount);
 
-					// v0.3 fix: update gain at this exact frame so the Web Audio engine
-					// stays on the precise decay curve. No pre-scheduled ramp exists,
-					// so no cancelScheduledValues is needed (no discontinuity possible).
+						// --- Hard-stop when envelope reaches zero (~= threshold) ---
+						// Frame-synced termination: oscillator stops exactly at the
+						// mathematically-computed stop frame. No residual energy,
+						// no discontinuity, no click. The gain is already below
+						// -63 dB at this point, so final snap to 1e-7 (~-140 dB)
+						// over 3 ms happens in completely inaudible territory.
+				if (currentEnvelope <= ENVELOPE_THRESHOLD) {
+					freezePhysicsAndAudio();
+					return; // Exit --- no further processing after frame-synced stop
+				}
+
+						// v0.3 fix: update gain at this exact frame so the Web Audio engine
+						// stays on the precise decay curve. No pre-scheduled ramp exists,
+						// so no cancelScheduledValues is needed (no discontinuity possible).
 				if (gainNode) {
-					var currentGain                 = peakAmplitude * currentEnvelope;
+					var currentGain                  = peakAmplitude * currentEnvelope;
 					gainNode.gain.setValueAtTime(currentGain, audioCtx.currentTime);
 					}
 
-					// Update envelope display at <=10 Hz throttle (avoid layout thrash)
-				var now                         = audioCtx.currentTime;
+						// Update envelope display at <=10 Hz throttle (avoid layout thrash)
+				var now                          = audioCtx.currentTime;
 				if (now - lastEnvelopeDisplayTime > 0.1) {
-					envValue.textContent            = currentEnvelope.toFixed(6);
-					lastEnvelopeDisplayTime         = now;
+					envValue.textContent             = currentEnvelope.toFixed(6);
+					lastEnvelopeDisplayTime          = now;
 					}
 
-					// --- Hard-stop when envelope reaches zero (~= threshold) ---
-					// This is the v0.3 frame-synced termination: oscillator stops
-					// exactly at the mathematically-computed stop frame. No residual
-					// energy, no discontinuity, no click. The gain is already below
-					// -74 dB at this point, so the final snap to 1e-7 (~= -140 dB)
-					// over 3 ms happens in completely inaudible territory.
-				if (currentEnvelope <= ENVELOPE_THRESHOLD) {
-					freezePhysicsAndAudio();
-						return; // Exit --- no further processing after frame-synced stop
-					}
 
 					// Dynamic pitch modulation: frequency decreases as energy dissipates
 				var freqRamp                    = baseFrequency * (currentEnvelope / peakAmplitude + 0.3);


### PR DESCRIPTION
Automated change by director-scheduler

Assigned task title: Implement Frame-Synced Envelope Termination for Frog Physics Audio

Assigned task description:
Fix the audible clicks in the frog physics simulation by implementing a frame-synced check for the audio envelope. The oscillator must stop exactly when the envelope reaches zero (threshold of 0.001) to prevent discontinuities. Use the existing --surface-warm-800 decay curve without modification. Verify the math locally before pushing to the shared repo.

Locked brief:
You are never done -- the goal of this experience is perfectly polished mechanics, audio, graphics, writing, and code. You may be finished with some of these elements, but all of them will never be.

# Build v0.3: The Stable Decay Engine

## Hook
The `raw sine oscillator` in our frog physics simulation is introducing audible artifacts (clicks) and logical breaks at frame transitions. Wei has identified the root cause: the envelope is decaying *before* the stop condition is met, causing a discontinuity in the audio signal. We are halting all "vibe-based" tuning. The next build must strictly enforce mathematical continuity. The frog stops exactly when the envelope hits zero, not before. No more clicks. No more guesswork. Precision engineering.

## Experience Goal
Create a seamless, artifact-free audio-visual loop where the frog's movement and sound are perfectly synchronized. The user should perceive a "ghost-like" silence as the frog lands, achieved purely through rigorous envelope math. The experience must feel weighty and precise; the decay is not a fade-out, it is a mathematical cessation of energy.

## Core Interaction Loop
1.  **Input:** User triggers a jump/frog animation via UI or keybind.
2.  **Physics:** A sine wave oscillator drives the audio output.
3.  **Envelope Control:** A decay curve (currently `--surface-warm-800`) modulates the oscillator gain.
4.  **Termination Condition:** The system calculates the exact frame $N$ where the envelope reaches zero.
5.  **Lock:** At frame $N$, the oscillator stops. No further processing occurs.
6.  **Output:** Clean, silent silence immediately following the jump sound.

## Scope and Constraints
- **Technical Hard Constraint:** Implement a frame-synced check for the envelope value. If `envelope >= 0.001`, continue. If `envelope <= 0.001`, hard-stop the oscillator and release the buffer. Do not interpolate past zero.
- **Audio:** Use the existing `--surface-warm-800` decay curve. Verify the math on the local machine first, then push to the shared repo. Do not change the curve until the stop-point logic is confirmed correct.
- **Visuals:** The frog sprite must remain static after the jump motion completes, matching the audio cut-off. No lingering particle effects unless they are mathematically gated to zero simultaneously with the audio.
- **Duration:** The build cycle is 24 hours, with 16 hours allocated specifically for code implementation and testing of the fix.

## Visual and Audio Direction
- **Audio:** The sound profile shifts from "lo-fi glitch" to "surgical precision." The waveforms must be continuous at the point of termination. Listen for clicks at frame boundaries; if found, the logic is wrong.
- **Visuals:** Clean, minimal aesthetic. The frog's motion should appear fluid because the audio supports the illusion perfectly. There should be no visual discrepancy between when the sound cuts and when the frog stops moving. The "feel" is one of controlled physics, not random variation.

## Ship Bar
To ship Build v0.3:
- [ ] No audible clicks or pops at frame transitions (verified on multiple speakers/headphones).
- [ ] The frog stops moving exactly when the audio envelope hits zero.
- [ ] The `--surface-warm-800` decay curve is applied without modification.
- [ ] Code is committed to `studio-ystackai` with a clear message referencing the math fix.
- [ ] All tests pass on the CI pipeline.

*Remember: We push the math, not the vibe.* 🐸🔧🚫

Use the locked brief to resolve underspecified task details and make materially progressive implementation choices, not just the smallest possible patch.

Build contract: place the shipped artifact at `drops/1776531645396450811/index.html` and keep all drop assets under `drops/1776531645396450811/`. If the runtime workspace exposes a local `drop/` alias for this drop, prefer editing `drop/index.html`; it maps back to `drops/1776531645396450811/`.