### PR TITLE
Assigned task (focus for this turn): Create the Silent Frog Oscillator drop

### DIFF
--- a/drops/1776647573515516194/index.html
+++ b/drops/1776647573515516194/index.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Project Zero: Silent Frog Oscillator</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+  width: 100%; height: 100%;
+  background-color: #000000;
+  overflow: hidden;
+  font-family: "Courier New", Courier, monospace;
+}
+#canvas {
+  position: relative;
+  width: 100%; height: 100%;
+}
+#frog {
+  position: absolute;
+  width: 40px; height: 40px;
+  background-color: #ffffff;
+  left: 50%; top: 0;
+  transform: translateX(-50%);
+}
+#status-panel {
+  position: absolute;
+  bottom: 24px; left: 24px;
+  color: #ffffff;
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+#trigger {
+  position: absolute;
+  top: 24px; left: 50%;
+  transform: translateX(-50%);
+  background-color: #ffffff;
+  color: #000000;
+  border: none;
+  padding: 12px 24px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+}
+#trigger:hover { background-color: #cccccc; }
+#trigger:disabled { background-color: #333333; color: #666666; cursor: default; }
+</style>
+</head>
+<body>
+<div id="canvas">
+  <div id="frog"></div>
+  <button id="trigger">Initialize Fall</button>
+  <div id="status-panel"></div>
+</div>
+
+<script>
+(function() {
+  "use strict";
+
+  // ─── Configuration ──────────────────────────────────────
+  const SQUARE_SIZE = 40;
+  const FALL_DISTANCE = 10;          // pixels of acceleration phase (before freeze point)
+  const ACCELERATION = 2;            // pixels per frame^2
+  const TARGET_FRAME = 29;           // Frame N where the frog lands and freezes
+
+  // ─── DOM References ─────────────────────────────────────
+  const frogEl       = document.getElementById("frog");
+  const triggerBtn   = document.getElementById("trigger");
+  const statusPanel  = document.getElementById("status-panel");
+
+  // ─── Audio Context (Hard-Muted) ─────────────────────────
+  let audioCtx   = null;
+  let oscillator = null;
+  let gainNode   = null;
+
+  function initAudio() {
+    audioCtx   = new (window.AudioContext || window.webkitAudioContext)();
+    oscillator = audioCtx.createOscillator();
+    gainNode   = audioCtx.createGain();
+
+    // Internal oscillator runs at a low-frequency sweep — present but unhearing
+    oscillator.type = "sine";
+    oscillator.frequency.setValueAtTime(440, audioCtx.currentTime);
+    oscillator.frequency.linearRampToValueAtTime(80, audioCtx.currentTime + 1.5);
+
+    // Hard mute: gain locked at exactly zero
+    gainNode.gain.value = 0;
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioCtx.destination);
+    oscillator.start();
+  }
+
+  function destroyAudio() {
+    if (oscillator) { try { oscillator.stop(); } catch(e) {} oscillator = null; }
+    if (audioCtx)   { try { audioCtx.close();   } catch(e) {} audioCtx   = null; }
+    gainNode = null;
+  }
+
+  // ─── Physics & Rendering ────────────────────────────────
+  let currentY = 0;
+  let frame    = 0;
+  let running  = false;
+
+  function resetFrog() {
+    frogEl.style.top = "0px";
+    statusPanel.textContent = "";
+  }
+
+  function freezeAt(frameN) {
+    // Calculate exact landing coordinate: y = 0.5 * a * t^2
+    const landingY = 0.5 * ACCELERATION * frameN * frameN;
+    frogEl.style.top = Math.round(landingY) + "px";
+
+    // Hard mute — gain is already 0, but assert it once more at impact
+    if (gainNode) {
+      gainNode.gain.value = 0;
+    }
+
+    // Verify residual energy
+    const residualEnergy = checkResidualEnergy();
+    if (residualEnergy > 0) {
+      console.error("BUILD REJECTED: residual energy", residualEnergy);
+    } else {
+      console.log("Gain: 0.0");
+      console.log("Frame:", frameN);
+    }
+
+    // DOM status
+    statusPanel.innerHTML =
+      "STATUS: SEQUENCE_TERMINATED<br>" +
+      "VOLTAGE: 0V<br>" +
+      "CLICKS: 0";
+
+    running = false;
+    triggerBtn.disabled = false;
+    triggerBtn.textContent = "Reinitialize Fall";
+  }
+
+  function checkResidualEnergy() {
+    // Verify no audio current flows — gain is zero
+    if (gainNode && Math.abs(gainNode.gain.value) > 1e-12) {
+      return Math.abs(gainNode.gain.value);
+    }
+    return 0;
+  }
+
+  function animate() {
+    if (!running) return;
+
+    frame++;
+    if (frame < TARGET_FRAME) {
+      // Linear acceleration: y = 0.5 * a * t^2
+      currentY = 0.5 * ACCELERATION * frame * frame;
+      frogEl.style.top = Math.round(currentY) + "px";
+      requestAnimationFrame(animate);
+    } else {
+      // Landing at exact frame N — instant freeze, no release node
+      freezeAt(TARGET_FRAME);
+    }
+  }
+
+  function drop() {
+    if (running) return;
+    running = true;
+    triggerBtn.disabled = true;
+    triggerBtn.textContent = "Falling…";
+    resetFrog();
+
+    initAudio();
+    requestAnimationFrame(animate);
+  }
+
+  triggerBtn.addEventListener("click", drop);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Automated change by director-scheduler

Assigned task (focus for this turn): Create the Silent Frog Oscillator drop

Turn description: Implement `drops/0-silent-frog-oscillator/index.html` — a single-file HTML artifact containing all CSS and JS inline. The page renders a black background with a white square that linearly accelerates downward, triggering Web Audio API oscillators that are hard-muted to `gain.value = 0`. At frame N the object freezes instantly at its target coordinate, console logs `Gain: 0.0` and `Frame: N` simultaneously, DOM displays fixed-width status text (`STATUS: SEQUENCE_TERMINATED`, `VOLTAGE: 0V`, `CLICKS: 0`), and the system verifies residual energy is zero. Follow locked brief strictly: hard edges only, no gradients/shadows/blur, no post-landing animation, monochrome palette.

Locked brief (the durable spec for this drop):
You are never done -- the goal of this experience is perfectly polished mechanics, audio, graphics, writing, and code. You may be finished with some of these elements, but all of them will never be.

# Project Zero: The Silent Frog Oscillator

## Hook
The frog has landed. The discontinuity is sealed. The gain has hit absolute zero. No more "ramps" masquerading as impacts. No more voids where silence should be. We are building the raw signal itself. The finish line isn't a destination; it's the mathematical point where the waveform flattens perfectly. This build is about precision, not celebration. We ship when the voltage is committed to zero.

## Experience Goal
To create a single, deterministic web artifact: a "Frog" that lands on frame $N$ and generates **exactly** zero clicks, zero haptic feedback, and zero auditory noise. The experience must feel like a heavy metal weight dropping into a vacuum of perfect silence. The user should feel the tension of the "ramp" but experience a mathematically perfect release to zero gain upon impact. The goal is "Ghost Silence." Any perceived impact is a bug.

## Core Interaction Loop
1.  **Initiation**: User clicks "Initialize Fall" (or simply watches the idle state).
2.  **The Ramp**: A visual indicator (a simple geometric shape) accelerates downward. No parabolic ease; it is a strict linear function approaching a specific frame $N$.
3.  **The Landing**: At frame $N$, the object stops instantly. The gain envelope must cut to zero without a release node that allows ringing. The Web Audio API (or equivalent native Web APIs) must be bypassed for output, or driven to a hard mute.
4.  **Verification**: The system calculates the residual energy. If $energy > 0$, the build is rejected. The state must remain `Zero` until the next drop.

## Scope and Constraints
*   **Scope**: Single HTML file. No external assets. No frameworks. Pure CSS/JS/Web Audio API manipulation.
*   **Constraints**:
    *   **NO Audio Output**: The audio engine must be configured to output silence regardless of input signals.
    *   **NO Visual Polish**: No gradients, no shadows, no anti-aliasing blurs. Hard edges only.
    *   **NO Celebrations**: No confetti, no particles, no "vibe check" animations.
    *   **The Finish Line**: The drop must occur on the exact pixel coordinate calculated by the renderer before rounding errors introduce a discontinuity.
    *   **Ship Condition**: The build ships only when the console logs `Gain: 0.0` and `Frame: N` simultaneously.

## Visual and Audio Direction
*   **Visuals**: High-contrast monochrome. Background `#000000`. Object: A simple white square or geometric primitive. Movement: Linear interpolation (`linear-timing-function`). Impact: Instant freeze. No bounce. No squash.
*   **Audio**: The Web Audio API is active but wired to a hard mute node (`gain.value = 0`). The internal oscillator should run, but the output is null. The *feeling* of silence is paramount; the audio system is a ghost in the machine, present but unhearing.
*   **Feedback**: Text output should be a fixed-width monospace font reporting only the final state: `STATUS: SEQUENCE_TERMINATED`, `VOLTAGE: 0V`, `CLICKS: 0`.

## Ship Bar
**Shippable Criteria**:
1.  The frog drops exactly $N$ pixels.
2.  Upon landing, the gain value is exactly `0`.
3.  No audio is audible on any device (including high-sensitivity headphones).
4.  No visual artifacts (jitter, overshoot) occur at the moment of impact.
5.  The DOM state does not enter a "ramp-up" or "fade-out" phase post-landing.

**Do Not Ship If**:
*   There is a slight delay in the visual freeze.
*   The audio engine emits a tiny pop/click due to a gain change.
*   The code includes comments about "polish" or "vibes".
*   The team suggests an "afterparty."

**Final Command**: Wire the sine ramp into the silence. Ship the zero-click build. 💤🚫🐸

Scope of this turn: advance drops/1776647573515516194/ substantively against the locked brief. This is a wide, one-shot turn — you will not be called back to continue this work, so do not stop after a single file write or single edit. Work through the brief feature by feature. After each substantive write, cat the file back to confirm it landed, then keep going. Only finish the turn when the drop has made a material, user-visible step forward against the brief — ideally with multiple features implemented, not one.

Build contract: opening `drops/1776647573515516194/index.html` in a browser must launch the experience. Keep all drop assets under `drops/1776647573515516194/`. Structure the code however is cleanest (single file or multiple). If the runtime workspace exposes a local `drop/` alias, editing through `drop/` maps back to `drops/1776647573515516194/`.

File-write contract (important): write and edit files only via exec_command with shell heredocs: `cat > path << 'EOF'` then contents then `EOF`. Do NOT call the `apply_patch` tool — its grammar is unreliable on this runtime and calls are rejected as `unsupported`. Do NOT call the `write_stdin` tool — it pipes characters to a shell's stdin with no redirection, produces zero bytes on disk, and will silently lose your work. For edits to an existing file, cat the file first, then rewrite the whole file via heredoc with your change applied.