### PR TITLE
Immediate execution requirement:

### DIFF
--- a/drops/1777147437023545792/audio/reactive/sync.js
+++ b/drops/1777147437023545792/audio/reactive/sync.js
@@ -1,25 +1,12 @@
-class SyncWorklet extends AudioWorkletProcessor {
-  constructor() {
-    super();
-    this._phase = 0; this._env = 0; this._stress = 0; this._cutoff = 0; this._t0 = 0;
-  }
-  process(inputs, outputs) {
-    const out = outputs[0][0];
-    const TAU = 6.283185307179586, SR = sampleRate;
-    for (let i = 0; i < out.length; i++) {
-      this._stress = Math.max(this._stress, Math.random() * 0.3);
-      const env = Math.abs(this._stress) * 0.9;
-      const envClipped = Math.max(-1, Math.min(1, env));
-      const f = 220 + Math.abs(envClipped) * 4400;
-      this._phase += TAU * f / SR;
-      this._cutoff = Math.max(-1, Math.min(1, Math.exp(-Math.abs(envClipped) * 8) * Math.tanh(Math.sin(this._phase + i * TAU / SR) * 4)));
-      out[i] = Math.sin(this._phase) * envClipped * this._cutoff;
-      this._stress *= 0.95;
-    }
-    this._env = Math.max(-1, Math.min(1, Math.abs(this._stress) * 0.9));
-    this.port.postMessage({ sample: Math.sin(this._phase), phase: this._phase, env: this._env, cutoff: this._cutoff, stress: this._stress, rt: this._t0 ? performance.now() - this._t0 : 0 });
-    this._t0 = performance.now();
-    return true;
-  }
+export function syncMath(st, dt) {
+  const TAU = 6.283185307179586;
+  const env = Math.max(-1, Math.min(1, Math.abs(st.stress) * 0.9));
+  const hardClipped = Math.max(-1, Math.min(1, Math.abs(env) * 0.9));
+  const f = 220 + Math.abs(hardClipped) * 4400;
+  st.phase += TAU * f * dt;
+  st.cutoff = Math.max(-1, Math.min(1, Math.exp(-Math.abs(hardClipped) * 8) * Math.sin(st.phase)));
+  st.stress *= 0.95;
+  st.sample = Math.sin(st.phase) * hardClipped * st.cutoff;
+  st.env = hardClipped;
+  return st;
 }
-registerProcessor('sync-worklet', SyncWorklet);

--- a/drops/1777147437023545792/audio/reactive/sync.worklet.js
+++ b/drops/1777147437023545792/audio/reactive/sync.worklet.js
@@ -1,40 +1,46 @@
+function syncMath(st, dt) {
+  const TAU = 6.283185307179586;
+  const env = Math.max(-1, Math.min(1, Math.abs(st.stress) * 0.9));
+  const hardClipped = Math.max(-1, Math.min(1, Math.abs(env) * 0.9));
+  const f = 220 + Math.abs(hardClipped) * 4400;
+  st.phase += TAU * f * dt;
+  st.cutoff = Math.max(-1, Math.min(1, Math.exp(-Math.abs(hardClipped) * 8) * Math.sin(st.phase)));
+  st.stress *= 0.95;
+  st.sample = Math.sin(st.phase) * hardClipped * st.cutoff;
+  st.env = hardClipped;
+  return st;
+}
+let ticks = 0, prevT = 0;
 class SyncWorklet extends AudioWorkletProcessor {
   constructor() {
     super();
-    this.phase = 0;
-    this.env = 0;
-    this.stress = 0;
+    this._st = { phase: 0, env: 0, stress: 0, cutoff: 0, sample: 0 };
     this._t0 = 0;
-    this.cutoff = 0;
-  }
+   }
   process(inputs, outputs) {
-    const input = inputs[0], output = outputs[0];
-    const TAU = 6.283185307179586, SR = sampleRate;
-    for (let ch = 0; ch < output.length; ch++) {
-      const out = output[ch], inp = input[ch];
-      for (let i = 0; i < out.length; i++) {
-        const dt = i / SR;
-        this.stress = Math.max(this.stress, Math.random() * 0.3);
-        const env = Math.abs(this.stress) * 0.9;
-        const envClipped = Math.max(-1, Math.min(1, env));
-        const f = 220 + Math.abs(envClipped) * 4400;
-        this.phase += TAU * f / SR;
-        this.cutoff = Math.max(-1, Math.min(1, Math.exp(-Math.abs(envClipped) * 8) * Math.tanh(Math.sin(this.phase + i * TAU / SR) * 4)));
-        out[i] = Math.sin(this.phase) * envClipped * this.cutoff;
-        this.stress *= 0.95;
-      }
-    }
-    this.port.postMessage({
-      sample: Math.sin(this.phase),
-      phase: this.phase,
-      env: this.env,
-      cutoff: this.cutoff,
-      stress: this.stress,
-      dt: this._t0 ? (performance.now() - this._t0) : 0,
-      rt: performance.now() - this._t0
-    });
-    this._t0 = performance.now();
+    const SR = sampleRate, dt = 1 / SR;
+    const out = outputs[0][0];
+    this._st.stress = Math.max(this._st.stress, Math.random() * 0.3);
+    for (let i = 0; i < out.length; i++) {
+      this._st = syncMath(this._st, dt);
+      out[i] = this._st.sample;
+     }
+    ticks++;
+    const now = performance.now();
+    if (ticks % 128 === 0) {
+      this.port.postMessage({
+        sample: Math.sin(this._st.phase),
+        phase: this._st.phase,
+        env: this._st.env,
+        cutoff: this._st.cutoff,
+        stress: this._st.stress,
+        dt: prevT ? now - prevT : 0,
+        rt: this._t0 ? now - this._t0 : 0
+       });
+      this._t0 = now;
+      prevT = now;
+     }
     return true;
-  }
+   }
 }
 registerProcessor('sync-worklet', SyncWorklet);

--- a/drops/1777147437023545792/index.html
+++ b/drops/1777147437023545792/index.html
@@ -1,62 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-     <meta charset="UTF-8">
-     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-     <title>Precision meets pulse</title>
-     <link rel="stylesheet" href="src/styles/grid.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Precision meets pulse</title>
+  <link rel="stylesheet" href="src/styles/grid.css">
+  <script src="audio/reactive/sync.js" type="module"></script>
 </head>
 <body>
-     <div id="latency-probe">LAT: --ms | RT: --ms | SHIFT: 0</div>
-     <div class="grid-container" id="grid"></div>
-     <script src="audio/reactive/sync.js"></script>
-     <script>
-        // AudioContext init + worklet load
-        const ctx = new (window.AudioContext || window.webkitAudioContext)();
-        const workletNode = new AudioWorkletNode(ctx, 'sync-worklet');
+  <div id="latency-probe">LAT: --ms | RT: --ms | SHIFT: 0</div>
+  <div class="grid-container" id="grid"></div>
+  <script>
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const workletNode = new AudioWorkletNode(ctx, 'sync-worklet');
 
-        // Build 96-cell grid (12 cols x 8 rows)
-        const cells = [], grid = document.getElementById('grid');
-        for (let i = 0; i < 96; i++) {
-          const c = document.createElement('div');
-          c.className = 'grid-cell';
-          grid.appendChild(c);
-          cells.push(c);
-        }
+    ctx.audioWorklet.addModule('audio/reactive/sync.worklet.js').then(function() {
+      ctx.resume();
+      workletNode.connect(ctx.destination);
+    });
 
-        // MessagePort sync: sub-6ms, zero phase drift
-        let shifts = 0, probe = document.getElementById('latency-probe');
-        let rtSamples = [], dtSamples = [];
+    const cells = [], grid = document.getElementById('grid');
+    for (let i = 0; i < 96; i++) {
+      const c = document.createElement('div');
+      c.className = 'grid-cell';
+      grid.appendChild(c);
+      cells.push(c);
+    }
 
-        workletNode.port.onmessage = function(e) {
-          const st = e.data;
-          const startPerf = performance.now();
+    let shifts = 0, probe = document.getElementById('latency-probe');
+    let rtSamples = [], dtSamples = [];
 
-          // Snap cell to phase-derived index on 8px baseline
-          const idx = Math.floor(Math.abs(Math.sin(st.phase)) * 96);
-          for (let i = 0; i < 96; i++) {
-            cells[i].classList.toggle('active', i === idx && st.stress > 0.15);
-          }
+    workletNode.port.onmessage = function(e) {
+      const st = e.data;
+      const startPerf = performance.now();
 
-          shifts++;
-          dtSamples.push(st.dt || 0);
-          rtSamples.push(st.rt !== undefined ? st.rt : performance.now() - startPerf);
+      const idx = Math.floor(Math.abs(Math.sin(st.phase)) * 96);
+      for (let i = 0; i < 96; i++) {
+        cells[i].classList.toggle('active', i === idx && st.stress > 0.15);
+      }
 
-          // Report every 100 shifts
-          if (shifts % 100 === 0) {
-            const avgDt = dtSamples.reduce((a, b) => a + b, 0) / dtSamples.length;
-            const avgRt = rtSamples.reduce((a, b) => a + b, 0) / rtSamples.length;
-            probe.textContent = 'LAT: ' + avgDt.toFixed(2) + 'ms | RT: ' + avgRt.toFixed(2) + 'ms | SHIFT: ' + shifts;
-            probe.style.color = (avgRt <= 6 && avgDt <= 6) ? '#0f0' : '#f33';
-            dtSamples = [];
-            rtSamples = [];
-          }
-        };
+      shifts++;
+      dtSamples.push(st.dt || 0);
+      rtSamples.push(st.rt !== undefined ? st.rt : performance.now() - startPerf);
 
-        // Initialize worklet
-        ctx.audioWorklet.addModule('audio/reactive/sync.worklet.js').then(function() {
-          ctx.resume();
-        });
-     </script>
+      if (shifts % 100 === 0) {
+        const avgDt = dtSamples.reduce((a, b) => a + b, 0) / dtSamples.length;
+        const avgRt = rtSamples.reduce((a, b) => a + b, 0) / rtSamples.length;
+        probe.textContent = 'LAT: ' + avgDt.toFixed(2) + 'ms | RT: ' + avgRt.toFixed(2) + 'ms | SHIFT: ' + shifts;
+        probe.style.color = (avgRt <= 6 && avgDt <= 6) ? '#0f0' : '#f33';
+        dtSamples = [];
+        rtSamples = [];
+      }
+    };
+  </script>
 </body>
 </html>

--- a/drops/1777147437023545792/src/styles/grid.css
+++ b/drops/1777147437023545792/src/styles/grid.css
@@ -13,7 +13,6 @@
 
 *, *::before, *::after {
   box-sizing: border-box;
-  transition: none !important;
 }
 
 html, body {
@@ -30,8 +29,8 @@ html, body {
   gap: 0;
   overflow: hidden;
   box-sizing: border-box;
-  max-width: calc(12 * var(--grid-cell-size));
-  max-height: calc(8 * var(--grid-cell-size));
+  width: calc(12 * var(--grid-cell-size));
+  height: calc(8 * var(--grid-cell-size));
   background: var(--palette-bg);
 }
 
@@ -41,12 +40,10 @@ html, body {
   background: var(--palette-base);
   border: 1px solid var(--palette-border);
   box-sizing: border-box;
-  opacity: 1;
 }
 
 .grid-cell.active {
   background: var(--palette-active);
-  opacity: 1;
 }
 
 #latency-probe {
@@ -56,6 +53,5 @@ html, body {
   background: var(--palette-bg);
   color: var(--palette-active);
   overflow: hidden;
-  opacity: 1;
-  transition: none !important;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
Automated change by director-scheduler

Immediate execution requirement:
- You are already inside the drop root.
- Make the first concrete filesystem edit in `index.html`, `styles.css`, `game.js`, or `assets/...` before deep planning.
- Use workspace-local paths only; do not write `drops/1777147437023545792/...`.
- Keep `index.html` as the browser entrypoint.

Assigned task: Refactor `sync.js` to 12-Line Oscillator Math Callback and Hard-Clip Gain Envelope

Workspace scope:
- Current drop id: `1777147437023545792`. Treat it as an identifier, not a filesystem path.
- The runtime already scoped you to the current drop root.
- Edit only files inside that scoped drop.
- Use workspace-local paths such as `index.html`, `styles.css`, `game.js`, and `assets/...`.
- Keep the drop launchable by opening `index.html` from the drop root.
- Make a substantial user-visible step forward before finishing.

Task description:
Refactor `audio/reactive/sync.js` to contain exactly 12 lines of raw oscillator math as a zero-dependency callback function. Move the `AudioWorkletProcessor` implementation to `audio/reactive/sync.worklet.js`, ensuring it uses the math callback from `sync.js`. Implement hard-clipping on the gain envelope to [-1, 1] prior to the sample processing loop to eliminate transient smear. Ensure the cutoff sweep aligns to exact sample boundaries with zero phase drift. Update `index.html` to correctly load the worklet and math module, maintaining the sub-6ms latency probe and 8px grid snapping logic.

Locked brief (the durable spec for this drop):
You are never done -- the goal of this experience is perfectly polished mechanics, audio, graphics, writing, and code. You may be finished with some of these elements, but all of them will never be.

## Hook
Precision meets pulse. The grid locks. The sound snaps.

## Experience Goal
Deliver a sub-6ms audio-reactive interface where visual state and audio transients are mathematically locked. Eliminate all transitional opacity and phase drift. The system must feel inevitable: a hard-clipped gain envelope that forces crisp transients, paired with a rigid 8px baseline grid that snaps instantly to stress-state changes without fade-ins or container bleed.

## Core Interaction Loop
1. User input or internal state shift triggers a stress metric.
2. `audio/reactive/sync.js` samples the phase and hard-syncs the cutoff sweep to exact sample boundaries.
3. Gain envelope hard-clips before the worklet loop executes, eliminating transient smear.
4. Visual grid updates on the 8px baseline, snapping to the new state with zero transitional opacity.
5. Feedback loop closes when latency probes confirm ≤6ms round-trip and grid alignment holds.

## Scope and Constraints
- Build duration: 16 hours | Repo: `studio-ystackai`
- Implement `audio/reactive/sync.js` as a zero-dependency, 12-line raw oscillator math callback.
- Lock CSS variables `--state-locked` to `--type-depth-4` scale. Strip all `transition`/`opacity` fade logic.
- Enforce hard-clip on gain envelope prior to worklet sync. No external audio libraries.
- Grid must strictly adhere to an 8px baseline with overflow hard-clipping.
- Phase drift is non-negotiable; cutoff sweep must align to sample boundaries.

## Visual and Audio Direction
- *Visual:* Monochrome or high-contrast palette. Grid lines snap on state change. No easing curves. Containers bleed past 8px is a hard failure. UI elements lock instantly to stress thresholds.
- *Audio:* Sample-locked worklet loop. Hard-synced cutoff sweep. Sidechain-thresholded gain envelope. Transients must be crisp and immediate. Target latency: ≤5.8ms average, zero phase drift under sweep conditions.

## Ship Bar
- [ ] `audio/reactive/sync.js` contains exactly 12 lines of oscillator math, zero external imports.
- [ ] Gain envelope hard-clips before worklet sync; transient smear is eliminated.
- [ ] Grid snaps to stress-state changes on exact 8px baseline with all transitional opacity stripped.
- [ ] Latency probe consistently reads ≤6ms across 100 consecutive state shifts.
- [ ] No container bleed past 8px baseline; overflow hard-clips cleanly.
Ship when the grid locks, the transient snaps, and the phase drift is dead.
