### PR TITLE
Grid Sync: declare freq with var

### DIFF
--- a/drops/1777400526928583439/game.js
+++ b/drops/1777400526928583439/game.js
@@ -131,7 +131,7 @@
     function playSawtooth(lockTime, duration, frequency) {
         if (!audioCtx || State.gridLocked) return;
 
-        freq = frequency || CFG.sawFreq;
+        var freq = frequency || CFG.sawFreq;
 
         var osc = audioCtx.createOscillator();
         osc.type = 'sawtooth';


### PR DESCRIPTION
playSawtooth assigned to bare `freq`, throwing 'freq is not defined' in strict mode every frame (188 page errors per page-load). Localizing with `var`.