### PR TITLE
SalamanderY: spawn p1/p2 on different rows

### DIFF
--- a/drops/3-salamander/index.html
+++ b/drops/3-salamander/index.html
@@ -352,17 +352,17 @@
     state = {
       phase: 'idle',
       p1: {
-        pos: { x: 4, y: 10 },
+        pos: { x: 4, y: 7 },
         dir: 'right',
         dirQueue: [],
-        tail: [{ x: 3, y: 10 }, { x: 2, y: 10 }],
+        tail: [{ x: 3, y: 7 }, { x: 2, y: 7 }],
         score: 0,
       },
       p2: {
-        pos: { x: 15, y: 10 },
+        pos: { x: 15, y: 13 },
         dir: 'left',
         dirQueue: [],
-        tail: [{ x: 16, y: 10 }, { x: 17, y: 10 }],
+        tail: [{ x: 16, y: 13 }, { x: 17, y: 13 }],
         score: 0,
       },
       embers: [],


### PR DESCRIPTION
Both salamanders started on row 10, p1 right + p2 left, walking into each other in ~6 ticks (~600ms). Stagger to rows 7 and 13 so the opening is playable.